### PR TITLE
Handle ML service URL for calculate endpoint

### DIFF
--- a/ml-service/app.py
+++ b/ml-service/app.py
@@ -12,8 +12,7 @@ class AssessmentInput(BaseModel):
     soil_type: str
     annual_rainfall: float
 
-@app.post("/predict")
-def predict(data: AssessmentInput):
+def _run_prediction(data: AssessmentInput):
     result = k_means_v3.predict_harvest(
         roof_area=data.roof_area,
         roof_type=data.roof_type,
@@ -26,6 +25,16 @@ def predict(data: AssessmentInput):
         "efficiency": result["efficiency"],
         "inertia": result["inertia"]
     }
+
+
+@app.post("/predict")
+def predict(data: AssessmentInput):
+    return _run_prediction(data)
+
+
+@app.post("/calculate")
+def calculate(data: AssessmentInput):
+    return _run_prediction(data)
 
 if __name__ == "__main__":
     # Get the port from the environment variable, with a default for local testing


### PR DESCRIPTION
## Summary
- guard against missing ML_SERVICE_URL configuration in the assessment route
- normalize ML service endpoint to accept either base URLs or explicit /calculate or /predict paths

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d54cdf88a883289aff230920360e22