### PR TITLE
Keep backend and ML service awake with self pings

### DIFF
--- a/ml-service/app.py
+++ b/ml-service/app.py
@@ -1,10 +1,31 @@
+import asyncio
 import os
+from contextlib import suppress
+from datetime import datetime, timezone
+from typing import Optional
+
+import httpx
 from fastapi import FastAPI
 from pydantic import BaseModel
 import uvicorn
-import k_means_v3  
+import k_means_v3
 
 app = FastAPI()
+
+SELF_PING_URL = (os.environ.get("SELF_PING_URL") or os.environ.get("RENDER_EXTERNAL_URL") or "").rstrip("/")
+
+
+def _resolve_keep_alive_seconds() -> int:
+    raw_value = os.environ.get("KEEP_ALIVE_INTERVAL_SECONDS", "840")
+    try:
+        parsed = int(raw_value)
+    except (TypeError, ValueError):
+        parsed = 840
+    return max(parsed, 60)
+
+
+KEEP_ALIVE_SECONDS = _resolve_keep_alive_seconds()
+_keep_alive_task: Optional[asyncio.Task] = None
 
 class AssessmentInput(BaseModel):
     roof_area: float
@@ -12,8 +33,7 @@ class AssessmentInput(BaseModel):
     soil_type: str
     annual_rainfall: float
 
-@app.post("/predict")
-def predict(data: AssessmentInput):
+def _run_prediction(data: AssessmentInput):
     result = k_means_v3.predict_harvest(
         roof_area=data.roof_area,
         roof_type=data.roof_type,
@@ -26,6 +46,57 @@ def predict(data: AssessmentInput):
         "efficiency": result["efficiency"],
         "inertia": result["inertia"]
     }
+
+
+@app.post("/predict")
+def predict(data: AssessmentInput):
+    return _run_prediction(data)
+
+
+@app.post("/calculate")
+def calculate(data: AssessmentInput):
+    return _run_prediction(data)
+
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+
+async def _keep_awake_loop():
+    if not SELF_PING_URL:
+        return
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        while True:
+            try:
+                response = await client.get(f"{SELF_PING_URL}/health")
+                timestamp = datetime.now(timezone.utc).isoformat()
+                print(f"[KeepAlive] Ping succeeded: {response.status_code} at {timestamp}")
+            except Exception as exc:  # noqa: BLE001
+                print(f"[KeepAlive] Ping failed: {exc}")
+
+            await asyncio.sleep(KEEP_ALIVE_SECONDS)
+
+
+@app.on_event("startup")
+async def _start_keep_awake():
+    global _keep_alive_task
+    if SELF_PING_URL:
+        _keep_alive_task = asyncio.create_task(_keep_awake_loop())
+        print(f"[KeepAlive] Started for {SELF_PING_URL} (every {KEEP_ALIVE_SECONDS}s)")
+    else:
+        print("[KeepAlive] Disabled (missing SELF_PING_URL/RENDER_EXTERNAL_URL)")
+
+
+@app.on_event("shutdown")
+async def _stop_keep_awake():
+    global _keep_alive_task
+    if _keep_alive_task:
+        _keep_alive_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await _keep_alive_task
+        _keep_alive_task = None
 
 if __name__ == "__main__":
     # Get the port from the environment variable, with a default for local testing

--- a/ml-service/requirements.txt
+++ b/ml-service/requirements.txt
@@ -8,3 +8,4 @@ joblib
 python-dateutil
 pytz
 pydantic
+httpx


### PR DESCRIPTION
## Summary
- add a production-only keep-alive interval in the Express backend that pings its `/api/health` endpoint
- expose a `/health` route in the FastAPI ML service and run an async keep-awake loop when deployed
- add the `httpx` client dependency used for the ML service keep-alive pings

## Testing
- node --check src/app.js
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d54cdf88a883289aff230920360e22